### PR TITLE
Add GitHub Skills Activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. First part of the GitHub Certifications program to help with college applications.",
+        "schedule": "Wednesdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## Description
This PR adds the missing "GitHub Skills" activity that was announced by the principal in the school assembly.

## Changes
- Added "GitHub Skills" activity to the activities list in `src/app.py`
- Description mentions it's part of the GitHub Certifications program for college applications
- Scheduled for Wednesdays, 3:30 PM - 5:00 PM
- Maximum of 25 participants
- Ready for student registration

## Resolves
Closes #6 

## Testing
- Activity appears in the activities list
- Students can now sign up for GitHub Skills
- Registration deadline can be met (closes this week)

## Notes
This is time-sensitive as registration closes by the end of this week per the principal's announcement.