### PR TITLE
Add JWT auth with file-backed user persistence

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 fastapi
 uvicorn
+PyJWT

--- a/src/app.py
+++ b/src/app.py
@@ -5,11 +5,22 @@ A super simple FastAPI application that allows students to view and sign up
 for extracurricular activities at Mergington High School.
 """
 
-from fastapi import FastAPI, HTTPException
-from fastapi.staticfiles import StaticFiles
-from fastapi.responses import RedirectResponse
+import datetime
+import hashlib
+import hmac
+import json
 import os
+import secrets
+import threading
 from pathlib import Path
+from typing import Dict, Optional
+
+import jwt
+from fastapi import Depends, FastAPI, HTTPException, status
+from fastapi.responses import RedirectResponse
+from fastapi.security import HTTPAuthorizationCredentials, HTTPBearer
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel, EmailStr
 
 app = FastAPI(title="Mergington High School API",
               description="API for viewing and signing up for extracurricular activities")
@@ -18,6 +29,95 @@ app = FastAPI(title="Mergington High School API",
 current_dir = Path(__file__).parent
 app.mount("/static", StaticFiles(directory=os.path.join(Path(__file__).parent,
           "static")), name="static")
+
+SECRET_KEY = os.environ.get("AUTH_SECRET_KEY", "dev-secret-change-me")
+TOKEN_EXPIRATION_MINUTES = 60
+DATA_DIR = current_dir / "data"
+USERS_FILE = DATA_DIR / "users.json"
+_users_lock = threading.Lock()
+
+
+class AuthRequest(BaseModel):
+    email: EmailStr
+    password: str
+
+
+class AuthTokenResponse(BaseModel):
+    access_token: str
+    token_type: str = "bearer"
+
+
+def _hash_password(password: str, salt: Optional[str] = None) -> Dict[str, str]:
+    salt_bytes = secrets.token_bytes(16) if salt is None else bytes.fromhex(salt)
+    pwd_hash = hashlib.pbkdf2_hmac("sha256", password.encode("utf-8"), salt_bytes, 100_000)
+    return {"salt": salt_bytes.hex(), "hash": pwd_hash.hex()}
+
+
+def _verify_password(password: str, salt: str, expected_hash: str) -> bool:
+    candidate = _hash_password(password, salt)
+    return hmac.compare_digest(candidate["hash"], expected_hash)
+
+
+def _create_token(email: str) -> str:
+    now = datetime.datetime.utcnow()
+    payload = {
+        "sub": email,
+        "iat": int(now.timestamp()),
+        "exp": int((now + datetime.timedelta(minutes=TOKEN_EXPIRATION_MINUTES)).timestamp()),
+    }
+    token = jwt.encode(payload, SECRET_KEY, algorithm="HS256")
+    # PyJWT returns str on new versions and bytes on old; normalize
+    return token if isinstance(token, str) else token.decode("utf-8")
+
+
+def _decode_token(token: str) -> str:
+    try:
+        payload = jwt.decode(token, SECRET_KEY, algorithms=["HS256"])
+        email = payload.get("sub")
+        if not email:
+            raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token payload")
+        return email
+    except jwt.ExpiredSignatureError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Token expired")
+    except jwt.InvalidTokenError:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid token")
+
+
+def _ensure_data_dir() -> None:
+    DATA_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _load_users_from_disk() -> Dict[str, Dict[str, str]]:
+    _ensure_data_dir()
+    if not USERS_FILE.exists():
+        return {}
+    try:
+        with USERS_FILE.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+            return data if isinstance(data, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_users_to_disk(users: Dict[str, Dict[str, str]]) -> None:
+    _ensure_data_dir()
+    temp_path = USERS_FILE.with_suffix(".tmp")
+    with temp_path.open("w", encoding="utf-8") as f:
+        json.dump(users, f)
+    temp_path.replace(USERS_FILE)
+
+
+auth_scheme = HTTPBearer(auto_error=False)
+
+
+def get_current_user(credentials: Optional[HTTPAuthorizationCredentials] = Depends(auth_scheme)) -> str:
+    if credentials is None:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Missing credentials")
+    return _decode_token(credentials.credentials)
+
+
+# In-memory user store backed by file persistence
+users: Dict[str, Dict[str, str]] = _load_users_from_disk()
 
 # In-memory activity database
 activities = {
@@ -78,6 +178,42 @@ activities = {
 }
 
 
+@app.post("/auth/register", response_model=AuthTokenResponse)
+def register_user(auth_request: AuthRequest):
+    email = auth_request.email.lower()
+    if len(auth_request.password) < 8:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Password must be at least 8 characters")
+
+    with _users_lock:
+        if email in users:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="User already exists")
+
+        pwd = _hash_password(auth_request.password)
+        users[email] = {"hash": pwd["hash"], "salt": pwd["salt"]}
+        _save_users_to_disk(users)
+    token = _create_token(email)
+    return AuthTokenResponse(access_token=token)
+
+
+@app.post("/auth/login", response_model=AuthTokenResponse)
+def login(auth_request: AuthRequest):
+    email = auth_request.email.lower()
+    user = users.get(email)
+    if not user:
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+    if not _verify_password(auth_request.password, user["salt"], user["hash"]):
+        raise HTTPException(status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid credentials")
+
+    token = _create_token(email)
+    return AuthTokenResponse(access_token=token)
+
+
+@app.get("/auth/me")
+def read_current_user(current_user: str = Depends(get_current_user)):
+    return {"email": current_user}
+
+
 @app.get("/")
 def root():
     return RedirectResponse(url="/static/index.html")
@@ -89,44 +225,38 @@ def get_activities():
 
 
 @app.post("/activities/{activity_name}/signup")
-def signup_for_activity(activity_name: str, email: str):
-    """Sign up a student for an activity"""
-    # Validate activity exists
+def signup_for_activity(activity_name: str, current_user: str = Depends(get_current_user)):
+    """Sign up the current authenticated user for an activity"""
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
     activity = activities[activity_name]
+    email = current_user
 
-    # Validate student is not already signed up
     if email in activity["participants"]:
         raise HTTPException(
             status_code=400,
             detail="Student is already signed up"
         )
 
-    # Add student
     activity["participants"].append(email)
     return {"message": f"Signed up {email} for {activity_name}"}
 
 
 @app.delete("/activities/{activity_name}/unregister")
-def unregister_from_activity(activity_name: str, email: str):
-    """Unregister a student from an activity"""
-    # Validate activity exists
+def unregister_from_activity(activity_name: str, current_user: str = Depends(get_current_user)):
+    """Unregister the current authenticated user from an activity"""
     if activity_name not in activities:
         raise HTTPException(status_code=404, detail="Activity not found")
 
-    # Get the specific activity
     activity = activities[activity_name]
+    email = current_user
 
-    # Validate student is signed up
     if email not in activity["participants"]:
         raise HTTPException(
             status_code=400,
             detail="Student is not signed up for this activity"
         )
 
-    # Remove student
     activity["participants"].remove(email)
     return {"message": f"Unregistered {email} from {activity_name}"}


### PR DESCRIPTION
## Summary
- add JWT-based authentication with HS256, exp/iat, configurable secret
- persist users to a JSON file with thread-safe writes
- protect signup/unregister routes to use authenticated user identity

## Testing
- manual: import jwt in venv and verify version
